### PR TITLE
Do not display statistics for disabled buildings in advisor windows

### DIFF
--- a/src/window/advisor/education.c
+++ b/src/window/advisor/education.c
@@ -8,6 +8,7 @@
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 #include "graphics/text.h"
+#include "scenario/building.h"
 
 #define ADVISOR_HEIGHT 16
 
@@ -52,9 +53,23 @@ static int get_education_advice(void)
     return advice_id;
 }
 
+static void draw_disabled_building_row(int y_offset, int building_text_id)
+{
+    text_draw(" - ", 40, y_offset, FONT_NORMAL_WHITE, 0);
+    lang_text_draw(8, building_text_id, 67, y_offset, FONT_NORMAL_WHITE);
+    text_draw_centered("-", 150, y_offset, 100, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", 290, y_offset, 120, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", 420, y_offset, 200, FONT_NORMAL_WHITE, 0);
+}
+
 static void draw_building_row(int y_offset, building_type building, 
     int building_text_id, int people_text_id, int building_coverage, int pct_coverage)
 {
+    if (!scenario_building_allowed(building)) {
+        draw_disabled_building_row(y_offset, building_text_id + 1);
+        return;
+    }
+
     lang_text_draw_amount(8, building_text_id, building_count_total(building), 40, y_offset, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(building), 150, y_offset, 100, FONT_NORMAL_WHITE);
 

--- a/src/window/advisor/entertainment.c
+++ b/src/window/advisor/entertainment.c
@@ -12,6 +12,7 @@
 #include "graphics/panel.h"
 #include "graphics/text.h"
 #include "graphics/window.h"
+#include "scenario/building.h"
 #include "window/hold_festival.h"
 
 #define ADVISOR_HEIGHT 23
@@ -78,9 +79,24 @@ static void draw_festival_info(void)
     lang_text_draw_multiline(58, 18 + get_festival_advice(), 56, 305, 400, FONT_NORMAL_WHITE);
 }
 
+static void draw_disabled_building_row(int y_offset, int building_text_id)
+{
+    text_draw(" - ", 40, y_offset, FONT_NORMAL_WHITE, 0);
+    lang_text_draw(8, building_text_id, 67, y_offset, FONT_NORMAL_WHITE);
+    text_draw_centered("-", 150, y_offset, 100, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", 230, y_offset, 100, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", PEOPLE_OFFSET + 10, y_offset, 100, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", COVERAGE_OFFSET, y_offset, COVERAGE_WIDTH, FONT_NORMAL_WHITE, 0);
+}
+
 static void draw_building_row(int y_offset, building_type building, 
     int building_text_id, int building_coverage, int shows, int pct_coverage)
 {
+    if (!scenario_building_allowed(building)) {
+        draw_disabled_building_row(y_offset, building_text_id + 1);
+        return;
+    }
+
     lang_text_draw_amount(8, building_text_id, building_count_total(building), 40, y_offset, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(building), 150, y_offset, 100, FONT_NORMAL_WHITE);
     text_draw_number_centered(shows, 230, y_offset, 100, FONT_NORMAL_WHITE);
@@ -99,6 +115,11 @@ static void draw_building_row(int y_offset, building_type building,
 
 static void draw_hippodrome_row(int y_offset)
 {
+    if (!scenario_building_allowed(BUILDING_HIPPODROME)) {
+        draw_disabled_building_row(y_offset, 41);
+        return;
+    }
+
     lang_text_draw_amount(8, 40, building_count_total(BUILDING_HIPPODROME), 40, y_offset, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_HIPPODROME), 150, y_offset, 100, FONT_NORMAL_WHITE);
     text_draw_number_centered(city_entertainment_hippodrome_shows(), 230, y_offset, 100, FONT_NORMAL_WHITE);

--- a/src/window/advisor/health.c
+++ b/src/window/advisor/health.c
@@ -8,6 +8,7 @@
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 #include "graphics/text.h"
+#include "scenario/building.h"
 
 #define ADVISOR_HEIGHT 18
 
@@ -28,8 +29,22 @@ static int get_health_advice(void)
     }
 }
 
+static void draw_disabled_building_row(int y_offset, int building_text_id)
+{
+    text_draw(" - ", 40, y_offset, FONT_NORMAL_WHITE, 0);
+    lang_text_draw(8, building_text_id, 67, y_offset, FONT_NORMAL_WHITE);
+    text_draw_centered("-", 150, y_offset, 100, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", 290, y_offset, 120, FONT_NORMAL_WHITE, 0);
+    text_draw_centered("-", 440, y_offset, 160, FONT_NORMAL_WHITE, 0);
+}
+
 static void draw_building_row(int y_offset, building_type building, int building_text_id)
 {
+    if (!scenario_building_allowed(building)) {
+        draw_disabled_building_row(y_offset, building_text_id + 1);
+        return;
+    }
+
     lang_text_draw_amount(8, building_text_id, building_count_total(building), 40, y_offset, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(building), 150, y_offset, 100, FONT_NORMAL_WHITE);
     lang_text_draw_centered(56, 2, 290, y_offset, 120, FONT_NORMAL_WHITE);
@@ -38,6 +53,11 @@ static void draw_building_row(int y_offset, building_type building, int building
 
 static void draw_hospital_row(int y_offset)
 {
+    if (!scenario_building_allowed(BUILDING_HOSPITAL)) {
+        draw_disabled_building_row(y_offset, 31);
+        return;
+    }
+
     lang_text_draw_amount(8, 30, building_count_total(BUILDING_HOSPITAL), 40, y_offset, FONT_NORMAL_WHITE);
     text_draw_number_centered(building_count_active(BUILDING_HOSPITAL), 150, y_offset, 100, FONT_NORMAL_WHITE);
 

--- a/src/window/advisor/religion.c
+++ b/src/window/advisor/religion.c
@@ -8,6 +8,7 @@
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 #include "graphics/text.h"
+#include "scenario/building.h"
 
 static int get_religion_advice(void)
 {
@@ -34,8 +35,16 @@ static void draw_god_row(god_type god, int y_offset, building_type small_temple,
 {
     lang_text_draw(59, 11 + god, 40, y_offset, FONT_NORMAL_WHITE);
     lang_text_draw(59, 16 + god, 120, y_offset + 1, FONT_SMALL_PLAIN);
-    text_draw_number_centered(building_count_total(small_temple), 230, y_offset, 50, FONT_NORMAL_WHITE);
-    text_draw_number_centered(building_count_total(large_temple), 290, y_offset, 50, FONT_NORMAL_WHITE);
+    if (scenario_building_allowed(small_temple)) {
+        text_draw_number_centered(building_count_total(small_temple), 230, y_offset, 50, FONT_NORMAL_WHITE);
+    } else {
+        text_draw_centered("-", 230, y_offset, 50, FONT_NORMAL_WHITE, 0);
+    }
+    if (scenario_building_allowed(large_temple)) {
+        text_draw_number_centered(building_count_total(large_temple), 290, y_offset, 50, FONT_NORMAL_WHITE);
+    } else {
+        text_draw_centered("-", 290, y_offset, 50, FONT_NORMAL_WHITE, 0);
+    }
     text_draw_number_centered(city_god_months_since_festival(god), 360, y_offset, 50, FONT_NORMAL_WHITE);
     int width = lang_text_draw(59, 32 + city_god_happiness(god) / 10, 460, y_offset, FONT_NORMAL_WHITE);
     int bolts = city_god_wrath_bolts(god);
@@ -80,7 +89,11 @@ static int draw_background(void)
 
     // oracles
     lang_text_draw(59, 8, 40, 166, FONT_NORMAL_WHITE);
-    text_draw_number_centered(building_count_total(BUILDING_ORACLE), 230, 166, 50, FONT_NORMAL_WHITE);
+    if (scenario_building_allowed(BUILDING_ORACLE)) {
+        text_draw_number_centered(building_count_total(BUILDING_ORACLE), 230, 166, 50, FONT_NORMAL_WHITE);
+    } else {
+        text_draw_centered("-", 230, 166, 50, FONT_NORMAL_WHITE, 0);
+    }
 
     city_gods_calculate_least_happy();
 


### PR DESCRIPTION
Includes a small refactoring to make things easier for the entertainment, education and health advisors.

When hippodrome is disabled:
<img width="655" height="380" alt="image" src="https://github.com/user-attachments/assets/c902e710-20b2-4f82-8735-72dfa17bd2b9" />

During the second mission:
<img width="655" height="299" alt="image" src="https://github.com/user-attachments/assets/f91691c5-248f-40d7-9011-5e8da197f7d6" />
<img width="650" height="264" alt="image" src="https://github.com/user-attachments/assets/3981eb94-6f2d-41da-8807-29116958d1c3" />
<img width="650" height="380" alt="image" src="https://github.com/user-attachments/assets/3d1f0c60-9b72-44e7-9a88-79f69044cfe8" />
<img width="652" height="283" alt="image" src="https://github.com/user-attachments/assets/4988adb4-3aa2-46bd-971c-af65f3b0b1bb" />
