### PR TITLE
Do not show collapsed/burned building type if nowhere

### DIFF
--- a/src/window/building/utility.c
+++ b/src/window/building/utility.c
@@ -83,8 +83,10 @@ void window_building_draw_burning_ruin(building_info_context *c)
     outer_panel_draw(c->x_offset, c->y_offset, c->width_blocks, c->height_blocks);
     lang_text_draw_centered(111, 0, c->x_offset, c->y_offset + 10, BLOCK_SIZE * c->width_blocks, FONT_LARGE_BLACK);
 
-    lang_text_draw(41, c->rubble_building_type,
-        c->x_offset + 32, c->y_offset + BLOCK_SIZE * c->height_blocks - 173, FONT_NORMAL_BLACK);
+    if (c->rubble_building_type) {
+        lang_text_draw(41, c->rubble_building_type,
+            c->x_offset + 32, c->y_offset + BLOCK_SIZE * c->height_blocks - 173, FONT_NORMAL_BLACK);
+    }
     lang_text_draw_multiline(111, 1, c->x_offset + 32, c->y_offset + BLOCK_SIZE * c->height_blocks - 143,
         BLOCK_SIZE * (c->width_blocks - 4), FONT_NORMAL_BLACK);
 }
@@ -96,8 +98,10 @@ void window_building_draw_rubble(building_info_context *c)
     outer_panel_draw(c->x_offset, c->y_offset, c->width_blocks, c->height_blocks);
     lang_text_draw_centered(140, 0, c->x_offset, c->y_offset + 10, BLOCK_SIZE * c->width_blocks, FONT_LARGE_BLACK);
 
-    lang_text_draw(41, c->rubble_building_type,
-        c->x_offset + 32, c->y_offset + BLOCK_SIZE * c->height_blocks - 173, FONT_NORMAL_BLACK);
+    if (c->rubble_building_type) {
+        lang_text_draw(41, c->rubble_building_type,
+            c->x_offset + 32, c->y_offset + BLOCK_SIZE * c->height_blocks - 173, FONT_NORMAL_BLACK);
+    }
     lang_text_draw_multiline(140, 1, c->x_offset + 32, c->y_offset + BLOCK_SIZE * c->height_blocks - 143,
         BLOCK_SIZE * (c->width_blocks - 4), FONT_NORMAL_BLACK);
 }


### PR DESCRIPTION
Before:
<img width="477" height="266" alt="image" src="https://github.com/user-attachments/assets/1c7e667c-b387-4f87-bdbe-d2d9619a17c4" />

After:
<img width="474" height="268" alt="image" src="https://github.com/user-attachments/assets/e7cf5e0b-eeee-44b9-a633-7f9b081b5168" />
