### PR TITLE
Hide resources that cannot be traded in empire screen

### DIFF
--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -164,6 +164,9 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
+            if (trade_max <= 0) {
+                continue;
+            }
             draw_trade_resource(resource, trade_max, x_offset + 104 * index + 120, y_offset + 31);
             int trade_now = trade_route_traded(city->route_id, resource);
             if (trade_now > trade_max) {
@@ -185,6 +188,9 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
+            if (trade_max <= 0) {
+                continue;
+            }
             draw_trade_resource(resource, trade_max, x_offset + 104 * index + 120, y_offset + 62);
             int trade_now = trade_route_traded(city->route_id, resource);
             if (trade_now > trade_max) {
@@ -205,6 +211,9 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
+            if (trade_max <= 0) {
+                continue;
+            }
             draw_trade_resource(resource, trade_max, x_offset + index + 60, y_offset + 33);
             index += 32;
         }
@@ -214,6 +223,9 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
+            if (trade_max <= 0) {
+                continue;
+            }
             draw_trade_resource(resource, trade_max, x_offset + index + 110, y_offset + 33);
             index += 32;
         }
@@ -515,6 +527,9 @@ static void handle_input(const mouse *m, const hotkeys *h)
 
                     // we only want to handle resource buttons that the selected city trades
                     for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
+                        if (trade_route_limit(city->route_id, resource) <= 0) {
+                            continue;
+                        }
                         if (empire_object_city_sells_resource(obj->id, resource)) {
                             generic_buttons_handle_mouse(m, x_offset + 120 + 104 * index_sell, y_offset + 31,
                                 generic_button_trade_resource + resource - 1, 1, &button_id);
@@ -570,7 +585,7 @@ static int get_tooltip_resource(tooltip_context *c)
     
     int item_offset = lang_text_get_width(47, 5, FONT_NORMAL_GREEN);
     for (int r = RESOURCE_MIN; r < RESOURCE_MAX; r++) {
-        if (empire_object_city_sells_resource(object_id, r)) {
+        if (empire_object_city_sells_resource(object_id, r) && trade_route_limit(city->route_id, r) > 0) {
             if (is_mouse_hit(c, x_offset + 60 + item_offset, y_offset + 33, 26)) {
                 return r;
             }
@@ -579,7 +594,7 @@ static int get_tooltip_resource(tooltip_context *c)
     }
     item_offset += lang_text_get_width(47, 4, FONT_NORMAL_GREEN);
     for (int r = RESOURCE_MIN; r <= RESOURCE_MAX; r++) {
-        if (empire_object_city_buys_resource(object_id, r)) {
+        if (empire_object_city_buys_resource(object_id, r) && trade_route_limit(city->route_id, r) > 0) {
             if (is_mouse_hit(c, x_offset + 110 + item_offset, y_offset + 33, 26)) {
                 return r;
             }


### PR DESCRIPTION
In Damascus:

Before:
<img width="502" height="203" alt="image" src="https://github.com/user-attachments/assets/df6edaca-3e18-4525-a2d3-6ba41eb8f312" /><br/>
<img width="470" height="200" alt="image" src="https://github.com/user-attachments/assets/c87bca90-a1f5-4f9a-9099-36b2e45a3bba" />

After:
<img width="503" height="215" alt="image" src="https://github.com/user-attachments/assets/55a73f03-79d6-4569-bf52-86a82fc3de6b" /><br/>
<img width="457" height="214" alt="image" src="https://github.com/user-attachments/assets/d5be660b-6112-429a-bc50-bd4684d26714" />
